### PR TITLE
feat (tds): Adding a card of "verbalize" in the page of activities and test of "AddClass "page

### DIFF
--- a/BACKEND/src/activity/activity.service.ts
+++ b/BACKEND/src/activity/activity.service.ts
@@ -30,6 +30,13 @@ export class ActivityService implements OnApplicationBootstrap {
             ' Dans cette zone de jeu les mots devrons être placés dans des champs et la zone de jeu comportera une image de background.',
           src: '/src/assets/logo/dalcard.svg',
         },
+        {
+          name: 'Verbalize',
+          description:
+            "Activité dans laquelle l'étudiant pourra apprendre à bien articuler" +
+            " Dans cette zone de jeu l'étudiant devra s'enregister pour savoir s'il a bien prononcer le mot proposer.",
+          src: '/src/assets/logo/verbalize.svg',
+        },
       ]);
     }
   }

--- a/WEB/src/components/__tests__/addClass/addclass.spec.ts
+++ b/WEB/src/components/__tests__/addClass/addclass.spec.ts
@@ -1,0 +1,40 @@
+import { shallowMount, mount, VueWrapper } from '@vue/test-utils'
+import AddClass from '@/components/Add classes/AddClass.vue'
+import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest'
+import { createTestingPinia } from '@pinia/testing'
+
+describe('AddClass.vue', () => {
+    let wrapper: any = null
+
+    beforeEach(() => {
+        wrapper = shallowMount(AddClass, {
+          global: {
+            plugins: [
+              createTestingPinia({
+                createSpy: vi.fn
+              })
+            ]
+          }
+        })
+      })
+
+      afterEach(() => {
+        wrapper.unmount()
+      })
+
+      it('initializes with first page displayed', () => {
+        expect(wrapper.findAll('div').length).toEqual(7)
+    
+        expect(wrapper.findAll('p').length).toEqual(2)
+    
+        expect(wrapper.findAll('button').length).toEqual(1)
+    
+        expect(wrapper.findAll('img').length).toEqual(1)
+
+        expect(wrapper.findAll('input').length).toEqual(1)
+
+        expect(wrapper.findAll('body').length).toEqual(0)
+
+        expect(wrapper.findAll('form').length).toEqual(1)
+      })
+})


### PR DESCRIPTION
# Description

This PR add a new activity "Verbalize" which is a new feature linked with the signal processing
project which will allow the user to learn the pronunciation of the
words which will be proposed to him and so this one will help the creators to
access the creation page for this activity

- Testing a page 'Addclass'
- Adding a new activity "Verbalize"